### PR TITLE
Revert "rate sort based on direct_priority provider type"

### DIFF
--- a/src/hotel-search/dataUtils.js
+++ b/src/hotel-search/dataUtils.js
@@ -84,12 +84,6 @@ module.exports = {
     var secondRateAmount = processRateAmount(secondRate);
     if (firstRateAmount != secondRateAmount) return firstRateAmount < secondRateAmount;
 
-    if (firstRate.provider.type == 'DIRECT_PRIORITY' && secondRate.provider.type != 'DIRECT_PRIORITY') {
-      return true;
-    } else if (secondRate.provider.type == 'DIRECT_PRIORITY' && firstRate.provider.type != 'DIRECT_PRIORITY') {
-      return false;
-    }
-
     return firstRate.price.ecpc > secondRate.price.ecpc;
   },
 

--- a/test/hotel-search/dataUtils.spec.js
+++ b/test/hotel-search/dataUtils.spec.js
@@ -264,58 +264,6 @@ describe('dataUtils', function() {
 
       expect(bestRateOf([r1, r2, r3])).to.equal(r3);
     });
-
-    it('compare two rates when price and provider type same', function() {
-      var r1 = {
-        price: {
-          amount: 10000,
-          ecpc: 1
-        },
-        provider: {
-          code: 'provider1',
-          type: 'DIRECT_PRIORITY'
-        }
-      };
-
-      var r2 = {
-        price: {
-          amount: 10000,
-          ecpc: 2
-        },
-        provider: {
-          code: 'provider2',
-          type: 'DIRECT_PRIORITY'
-        }
-      };
-
-      expect(bestRateOf([r1, r2])).to.equals(r2);
-    });
-
-    it('compare two rates when price is same but first with direct_priority provider', function() {
-      var r1 = {
-        price: {
-          amount: 10000,
-          ecpc: 1
-        },
-        provider: {
-          code: 'provider1',
-          type: 'DIRECT_PRIORITY'
-        }
-      };
-
-      var r2 = {
-        price: {
-          amount: 10000,
-          ecpc: 2
-        },
-        provider: {
-          code: 'provider2',
-          type: 'OTA'
-        }
-      };
-
-      expect(bestRateOf([r1, r2])).to.equals(r1)
-    });
   });
 
   function createStaticData(data) {


### PR DESCRIPTION
Reverts wego/wego-sdk-js#26

reverting as we dont have provider type in rate object. Need to work on to get it from staticData in response which is separate provider details. Its not good to keep unused code. so reverting it for now