### PR TITLE
Add filter by providers for flight leaderboard

### DIFF
--- a/src/flight-search/Merger.js
+++ b/src/flight-search/Merger.js
@@ -277,6 +277,7 @@ FlightSearchMerger.prototype = {
 
   __filterOptionTypes: [
     'airlines',
+    'providers',
     'stops',
     'alliances',
     'originAirports',

--- a/src/flight-search/dataUtils.js
+++ b/src/flight-search/dataUtils.js
@@ -292,5 +292,6 @@ module.exports = {
     originAirports: 'airports',
     destinationAirports: 'airports',
     stopoverAirports: 'airports',
+    providers: 'providers'
   }
 };

--- a/src/flight-search/filtering.js
+++ b/src/flight-search/filtering.js
@@ -59,6 +59,14 @@ function filterByAirlines(trip, airlineCodeMap) {
   return utils.filterByKey(trip.marketingAirline.code, airlineCodeMap);
 }
 
+function filterByProviders(trip, providerCodeMap) {
+  if (!providerCodeMap) return true;
+  for (var i = 0; i < trip.fares.length; i++) {
+    if (utils.filterByKey(trip.fares[i].provider.code, providerCodeMap)) return true;
+  }
+  return false;
+}
+
 function isBothAirlineAndInstant(value) {
   return value.provider.type === 'airline' || value.provider.instant;
 }
@@ -69,6 +77,7 @@ module.exports = {
 
     var stopCodeMap = utils.arrayToMap(filter.stopCodes);
     var airlineCodeMap = utils.arrayToMap(filter.airlineCodes);
+    var providerCodeMap = utils.arrayToMap(filter.providerCodes);
     var allianceCodeMap = utils.arrayToMap(filter.allianceCodes);
     var originAirportCodeMap = utils.arrayToMap(filter.originAirportCodes);
     var destinationAirportCodeMap = utils.arrayToMap(filter.destinationAirportCodes);
@@ -79,6 +88,7 @@ module.exports = {
         && filterByRanges(trip, filter.departureTimeMinutesRanges, 'departureTimeMinutes')
         && filterByRanges(trip, filter.arrivalTimeMinutesRanges, 'arrivalTimeMinutes')
         && filterByAirlines(trip, airlineCodeMap)
+        && filterByProviders(trip, providerCodeMap)
         && utils.filterByAllKeys(trip.allianceCodes, allianceCodeMap)
         && filterByTripOptions(trip, filter.tripOptions)
         && utils.filterByAllKeys(trip.originAirportCodes, originAirportCodeMap)

--- a/test/flight-search/filtering.spec.js
+++ b/test/flight-search/filtering.spec.js
@@ -126,6 +126,25 @@ describe('filtering', function() {
       expect(filtering.filterTrips([trip1, trip2, trip3, trip4], filter)).to.deep.equal([trip1, trip3]);
     });
 
+    it('filtering by providerCodes', function() {
+      var fare1 = createFareWithProvider('ota', 'wego.com-kiwi');
+      var fare2 = createFareWithProvider('ota');
+      var fare3 = createFareWithProvider('airline');
+
+      var trip1 = {
+        fares: [fare1, fare2]
+      };
+
+      var trip2 = {
+        fares: [fare2, fare3]
+      }
+
+      var filter = {
+        providerCodes: ['wego.com-kiwi']
+      };
+      expect(filtering.filterTrips([trip1, trip2], filter)).to.deep.equal([trip1]);
+    });
+
     it('filtering by allianceCodes', function() {
       var trip1 = {
         allianceCodes: ['A1', 'A3'],


### PR DESCRIPTION
This change is a part of the Flight leaderboard feature https://wegomushi.atlassian.net/browse/BE-47.
 The purpose is to have a filter by providers when users click the provider on leaderboard.