### PR TITLE
Combine filter by ProviderTypes and by ProviderCodes

### DIFF
--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -1630,7 +1630,7 @@ function filterByPrice(trip, priceRange) {
 
 /*
   e.g providerFilter: {
-    providerCodeMap: {citybookers.com: true, rehlat.ae: true},
+    providerCodeMap: {'citybookers.com': true, 'rehlat.ae': true},
     providerTypes: ['instant', 'airline'],
   }
 */

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -1630,7 +1630,7 @@ function filterByPrice(trip, priceRange) {
 
 /*
   e.g providerFilter: {
-    providerCodeMap: {citybookers.com: true, rehlat.ae: true},
+    providerCodeMap: {'citybookers.com': true, 'rehlat.ae': true},
     providerTypes: ['instant', 'airline'],
   }
 */

--- a/src/flight-search/filtering.js
+++ b/src/flight-search/filtering.js
@@ -7,7 +7,7 @@ function filterByPrice(trip, priceRange) {
 
 /*
   e.g providerFilter: {
-    providerCodeMap: {citybookers.com: true, rehlat.ae: true},
+    providerCodeMap: {'citybookers.com': true, 'rehlat.ae': true},
     providerTypes: ['instant', 'airline'],
   }
 */

--- a/src/flight-search/filtering.js
+++ b/src/flight-search/filtering.js
@@ -5,17 +5,39 @@ function filterByPrice(trip, priceRange) {
   return trip.fares[0] && utils.filterByRange(trip.fares[0].price.amountUsd, priceRange);
 }
 
-function filterByProviderTypes(trip, providerTypes) {
-  if (!providerTypes) return true;
-  var fares = trip.fares;
+/*
+  e.g providerFilter: {
+    providerCodeMap: {citybookers.com: true, rehlat.ae: true},
+    providerTypes: ['instant', 'airline'],
+  }
+*/
+function filterByProviders(trip, providerFilter) {
+  if (!providerFilter) return true;
 
+  var providerCodeMap = providerFilter.providerCodeMap;
+  var providerTypes = providerFilter.providerTypes;
+
+  if (!providerCodeMap && !providerTypes) return true;
+
+  var fares = trip.fares;
   if (!fares) return false;
   for (var i = 0; i < fares.length; i++) {
-    if (fares[i].provider.instant && providerTypes.includes('instant')) return true;
-    if (providerTypes.includes(fares[i].provider.type)) return true;
+    var isMatchCode = isFareMatchProviderCode(fares[i], providerCodeMap);
+    var isMatchType = isFareMatchProviderType(fares[i], providerTypes);
+    if (isMatchCode && isMatchType) return true;
   }
-
   return false;
+}
+
+function isFareMatchProviderType (fare, providerTypes) {
+  if (!providerTypes) return true;
+  var isMatchTypeInstant = (fare.provider.instant && providerTypes.includes('instant'));
+  return isMatchTypeInstant || (providerTypes.includes(fare.provider.type));
+}
+
+function isFareMatchProviderCode (fare, providerCodeMap) {
+  if(!providerCodeMap) return true;
+  return utils.filterByKey(fare.provider.code, providerCodeMap);
 }
 
 function filterByTripOptions(trip, tripOptions) {
@@ -59,14 +81,6 @@ function filterByAirlines(trip, airlineCodeMap) {
   return utils.filterByKey(trip.marketingAirline.code, airlineCodeMap);
 }
 
-function filterByProviders(trip, providerCodeMap) {
-  if (!providerCodeMap) return true;
-  for (var i = 0; i < trip.fares.length; i++) {
-    if (utils.filterByKey(trip.fares[i].provider.code, providerCodeMap)) return true;
-  }
-  return false;
-}
-
 function isBothAirlineAndInstant(value) {
   return value.provider.type === 'airline' || value.provider.instant;
 }
@@ -77,10 +91,13 @@ module.exports = {
 
     var stopCodeMap = utils.arrayToMap(filter.stopCodes);
     var airlineCodeMap = utils.arrayToMap(filter.airlineCodes);
-    var providerCodeMap = utils.arrayToMap(filter.providerCodes);
     var allianceCodeMap = utils.arrayToMap(filter.allianceCodes);
     var originAirportCodeMap = utils.arrayToMap(filter.originAirportCodes);
     var destinationAirportCodeMap = utils.arrayToMap(filter.destinationAirportCodes);
+
+    var providerCodeMap = utils.arrayToMap(filter.providerCodes);
+    var providerTypes = filter.providerTypes;
+    var providerFilter = {providerCodeMap, providerTypes};
 
     var filteredTrips = trips.filter(function(trip) {
       return filterByPrice(trip, filter.priceRange)
@@ -88,7 +105,6 @@ module.exports = {
         && filterByRanges(trip, filter.departureTimeMinutesRanges, 'departureTimeMinutes')
         && filterByRanges(trip, filter.arrivalTimeMinutesRanges, 'arrivalTimeMinutes')
         && filterByAirlines(trip, airlineCodeMap)
-        && filterByProviders(trip, providerCodeMap)
         && utils.filterByAllKeys(trip.allianceCodes, allianceCodeMap)
         && filterByTripOptions(trip, filter.tripOptions)
         && utils.filterByAllKeys(trip.originAirportCodes, originAirportCodeMap)
@@ -99,7 +115,7 @@ module.exports = {
         && utils.filterByRange(trip.stopoverDurationMinutes, filter.stopoverDurationMinutesRange)
         && filterByItineraryOptions(trip, filter.itineraryOptions)
         && utils.filterByContainAllKeys(trip.legIdMap, filter.legIds)
-        && filterByProviderTypes(trip, filter.providerTypes);
+        && filterByProviders(trip, providerFilter);
     });
 
     return filteredTrips;

--- a/test/flight-search/filtering.spec.js
+++ b/test/flight-search/filtering.spec.js
@@ -145,6 +145,30 @@ describe('filtering', function() {
       expect(filtering.filterTrips([trip1, trip2], filter)).to.deep.equal([trip1]);
     });
 
+    it('filtering by providerCodes and providerTypes', function() {
+      var fare1 = createFareWithProvider('ota', 'wego.com-kiwi');
+      var fare2 = createFareWithProvider('ota', 'trip.com');
+      var fare3 = createFareWithProvider('airline', 'vietjetair.com');
+
+      var trip1 = {
+        fares: [fare1, fare2]
+      };
+
+      var trip2 = {
+        fares: [fare2]
+      };
+
+      var trip3 = {
+        fares: [fare2, fare3]
+      };
+
+      var filter = {
+        providerCodes: ['wego.com-kiwi', 'vietjetair.com'],
+        providerTypes: ['instant', 'airline']
+      };
+      expect(filtering.filterTrips([trip1, trip2, trip3], filter)).to.deep.equal([trip1, trip3]);
+    });
+
     it('filtering by allianceCodes', function() {
       var trip1 = {
         allianceCodes: ['A1', 'A3'],


### PR DESCRIPTION
Purpose: 
As of now we can filter trips by:
+ `providerTypes` (e.g. `['instant, 'airline']`) from the filter. 
+ `providerCodes` (e.g. `['kiwi.com', 'vietjetair.com']`) from the leaderboard.

However, these two filters should be combined together when users do a combination filters. Because the `providerType` and `providerCode` are just 2 properties of a provider.

Already tested on local env and staging.
  