### PR TITLE
Adding force stop behave to polling process

### DIFF
--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -918,7 +918,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    response["isLastPolling"] = this.poller.isLastPolling();
+    response.isLastPolling = this.poller.isLastPolling();
     this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -2002,6 +2002,9 @@ HotelSearchClient.prototype = {
       var hotelId = singlePartnerHotels[i];
       var currentBestRate = self.__hotelMap[hotelId].rates[0];
       var rates = hotelIdToNewRatesMap[hotelId];
+      if (!rates) {
+        continue;
+      }
       rates = rates.filter(rate => rate.id !== currentBestRate.id)
       rates.push(currentBestRate);
       self.__hotelMap[hotelId].rates = rates.sort(compareRates);

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -887,11 +887,7 @@ var HotelSearchClient = function(options) {
       });
     },
     callApi: function() {
-      var query = self.fetchHotelsParams();
-      if (self.poller.pollCount > self.poller.pollLimit) {
-        query["isLastPolling"] = true;
-      }
-      return Api.fetchHotels(self.responseSearch.id, query);
+      return Api.fetchHotels(self.responseSearch.id, self.fetchHotelsParams());
     },
     onSuccessResponse: function(response) {
       return self.handleSearchResponse(response);
@@ -1012,6 +1008,10 @@ HotelSearchClient.prototype = {
     var selectedHotelIds = dataUtils.trimArray(this.selectedHotelIds);
     if (!!selectedHotelIds.length && Array.isArray(selectedHotelIds)) {
       params.selectedHotelIds = selectedHotelIds;
+    }
+
+    if (this.poller.pollCount > this.poller.pollLimit) {
+      params["isLastPolling"] = true;
     }
     return params;
   }

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -343,7 +343,6 @@ var Poller = function(options) {
   this.delays = options.delays;
   this.onSuccessResponse = options.onSuccessResponse;
   this.pollLimit = options.pollLimit;
-  this.forceStop = false;
 };
 
 Poller.prototype = {
@@ -363,6 +362,7 @@ Poller.prototype = {
     }
     this.pollCount = 0;
     this.resultCount = 0;
+    this.forceStop = false;
   },
 
   stop: function() {
@@ -875,20 +875,11 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var originDelays = [0, 300, 600, 900, 2400, 3800, 5000, 6000];
-  var approximateTime = originDelays.reduce((a,b) => a+b);
-  var timeout = 45000;
-  var stepTime = 6000;
-  var extendedDelays = originDelays.slice();
-  while (approximateTime < timeout) {
-    approximateTime += stepTime;
-    extendedDelays.push(stepTime);
-  }
-
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000, 6000, 6000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
-    delays: extendedDelays,
-    pollLimit: extendedDelays.length - 1,
+    delays: delays,
+    pollLimit: delays.length - 1,
     initCallApi: function() {
       return Api.searchHotels(self.getSearchRequestBody(), {
         currencyCode: self.currency.code,

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -875,7 +875,7 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000, 6000, 6000, 6000];
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
     delays: delays,

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -875,7 +875,7 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000];
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
     delays: delays,
@@ -887,7 +887,11 @@ var HotelSearchClient = function(options) {
       });
     },
     callApi: function() {
-      return Api.fetchHotels(self.responseSearch.id, self.fetchHotelsParams());
+      var query = self.fetchHotelsParams();
+      if (self.poller.pollCount > self.poller.pollLimit) {
+        query["isLastPolling"] = true;
+      }
+      return Api.fetchHotels(self.responseSearch.id, query);
     },
     onSuccessResponse: function(response) {
       return self.handleSearchResponse(response);

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -914,11 +914,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    if (response.done) {
-      this.merger.lastMergeResponse(response); 
-    } else {
-      this.merger.mergeResponse(response);  
-    }
+    this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
   },
@@ -1885,20 +1881,11 @@ HotelSearchClient.prototype = {
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    this._mergeRates(response.rates);
-    this._mergeScores(response.scores);
-    this._mergeRatesCounts(response.providerRatesCounts);
-
-    this._cloneHotels(hotelIds);
-  },
-
-  lastMergeResponse: function(response) {
-    var hotelIds = this._getUpdatedHotelIds(response);
-
-    this._mergeStaticData(response);
-    this._mergeHotels(response.hotels);
-    this._mergeFilter(response.filter);
-    this._lastMergeRates(response.rates);
+    if (response.done) {
+      this._lastMergeRates(response.rates);
+    } else {
+      this._mergeRates(response.rates);  
+    }
     this._mergeScores(response.scores);
     this._mergeRatesCounts(response.providerRatesCounts);
 
@@ -1991,44 +1978,34 @@ HotelSearchClient.prototype = {
 
     self._mergeRates(newRates);
 
-    var updatingHotel = [];
-    for (var hotelId in self.__hotelMap) {
-      if (self.__hotelMap[hotelId].rates.length === 1) {
-        updatingHotel.push(hotelId);
-      }
+    var singlePartnerHotels = Object.keys(self.__hotelMap).filter(hotelId => self.__hotelMap[hotelId].rates.length === 1);
+
+    var newPreparedRates = newRates.map(rate => {
+      dataUtils.prepareRate(rate, self.currency, self.__staticData);
+      return rate;
+    });
+
+    var hotelIdToNewRatesMap = newPreparedRates.reduce(function(map, rate) {
+      map[rate.hotelId] = map[rate.hotelId] || [];
+      map[rate.hotelId].push(rate);
+      return map;
+    }, {});
+
+    function compareRates(rate1, rate2) {
+      if (dataUtils.isBetterRate(rate1, rate2)) {
+        return -1;
+      } 
+      return 1;
     }
 
-    for (var i in newRates) {
-      var newRate = newRates[i];
-      dataUtils.prepareRate(newRate, self.currency, self.__staticData);
-      var hotelId = newRate.hotelId;
-      if (updatingHotel.includes(hotelId)) {
-        continue;
-      }
-      var hotel = self.__hotelMap[hotelId];
-      if (!hotel) {
-        continue;
-      }
-
-      var rates = hotel.rates;
-      var isIncluded = false;
-      for (var i = 0; i < rates.length; i++) {
-        if (newRate.id === rates[i].id) {
-          isIncluded = true;
-          break;
-        }
-      }
-      if (isIncluded) {
-        continue;
-      }
-      for (var i = 0; i < rates.length; i++) {
-        if (dataUtils.isBetterRate(newRate, rates[i])) {
-          rates.splice(i, 0, newRate);
-          continue;
-        }
-      }
-      rates.push(newRate);
-    }
+    for (var i in singlePartnerHotels) {
+      var hotelId = singlePartnerHotels[i];
+      var currentBestRate = self.__hotelMap[hotelId].rates[0];
+      var rates = hotelIdToNewRatesMap[hotelId];
+      rates = rates.filter(rate => rate.id !== currentBestRate.id)
+      rates.push(currentBestRate);
+      self.__hotelMap[hotelId].rates = rates.sort(compareRates);
+    } 
   },
 
   _mergeScores: function(scores) {

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -1016,7 +1016,7 @@ HotelSearchClient.prototype = {
     }
 
     if (this.poller.isLastPolling()) {
-      params["isLastPolling"] = true;
+      params.isLastPolling = true;
     }
     return params;
   }
@@ -1997,7 +1997,10 @@ HotelSearchClient.prototype = {
     for (var i in newRates) {
       var rate = newRates[i];
       if (singlePartnerHotels[rate.hotelId]) {
-        var hotelOrderedRates = hotelIdToNewRatesMap[rate.hotelId] || [];
+        if (!hotelIdToNewRatesMap[rate.hotelId]) {
+          hotelIdToNewRatesMap[rate.hotelId] = [];
+        }
+        var hotelOrderedRates = hotelIdToNewRatesMap[rate.hotelId];
         var index;
         for (index = 0; index < hotelOrderedRates.length; index++) {
           if (dataUtils.isBetterRate(rate, hotelOrderedRates[index])) {
@@ -2005,7 +2008,6 @@ HotelSearchClient.prototype = {
           }
         }
         hotelOrderedRates.splice(index, 0, rate);
-        hotelIdToNewRatesMap[rate.hotelId] = hotelOrderedRates;
       }
     }
 

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -373,6 +373,10 @@ Poller.prototype = {
     return this.forceStop;
   },
 
+  isLastPolling: function() {
+    return this.pollCount > this.pollLimit;
+  },
+
   getProgress: function() {
     if (this.pollCount >= this.pollLimit || this.resultCount >= 1000) {
       return 100;
@@ -914,6 +918,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
+    response["isLastPolling"] = this.poller.isLastPolling();
     this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
@@ -1010,7 +1015,7 @@ HotelSearchClient.prototype = {
       params.selectedHotelIds = selectedHotelIds;
     }
 
-    if (this.poller.pollCount > this.poller.pollLimit) {
+    if (this.poller.isLastPolling()) {
       params["isLastPolling"] = true;
     }
     return params;
@@ -1885,7 +1890,7 @@ HotelSearchClient.prototype = {
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    if (response.done) {
+    if (response.done || response.isLastPolling) {
       this._lastMergeRates(response.rates);
     } else {
       this._mergeRates(response.rates);  

--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -918,8 +918,8 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    response.isLastPolling = this.poller.isLastPolling();
-    this.merger.mergeResponse(response);  
+    var isSearchEnd = response.done || this.poller.isLastPolling()
+    this.merger.mergeResponse(response, isSearchEnd);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
   },
@@ -1884,13 +1884,13 @@ HotelSearchClient.prototype = {
     this.__filterOptionsMap = this._getEmptyFilterOptionsMap();
   },
 
-  mergeResponse: function(response) {
+  mergeResponse: function(response, isSearchEnd = false) {
     var hotelIds = this._getUpdatedHotelIds(response);
 
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    this._mergeRates(response);  
+    this._mergeRates(response.rates, isSearchEnd);  
     this._mergeScores(response.scores);
     this._mergeRatesCounts(response.providerRatesCounts);
 
@@ -1949,8 +1949,7 @@ HotelSearchClient.prototype = {
     });
   },
 
-  _mergeRates: function(response) {
-    newRates = response.rates;
+  _mergeRates: function(newRates, isSearchEnd) {
     if (!newRates) return;
     var self = this;
 
@@ -1977,7 +1976,7 @@ HotelSearchClient.prototype = {
       }
     });
 
-    if (response.done || response.isLastPolling) {
+    if (isSearchEnd) {
       this._lastMergeRates(newRates);
     }
   },

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -918,7 +918,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    response["isLastPolling"] = this.poller.isLastPolling();
+    response.isLastPolling = this.poller.isLastPolling();
     this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -2002,6 +2002,9 @@ HotelSearchClient.prototype = {
       var hotelId = singlePartnerHotels[i];
       var currentBestRate = self.__hotelMap[hotelId].rates[0];
       var rates = hotelIdToNewRatesMap[hotelId];
+      if (!rates) {
+        continue;
+      }
       rates = rates.filter(rate => rate.id !== currentBestRate.id)
       rates.push(currentBestRate);
       self.__hotelMap[hotelId].rates = rates.sort(compareRates);

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -887,11 +887,7 @@ var HotelSearchClient = function(options) {
       });
     },
     callApi: function() {
-      var query = self.fetchHotelsParams();
-      if (self.poller.pollCount > self.poller.pollLimit) {
-        query["isLastPolling"] = true;
-      }
-      return Api.fetchHotels(self.responseSearch.id, query);
+      return Api.fetchHotels(self.responseSearch.id, self.fetchHotelsParams());
     },
     onSuccessResponse: function(response) {
       return self.handleSearchResponse(response);
@@ -1012,6 +1008,10 @@ HotelSearchClient.prototype = {
     var selectedHotelIds = dataUtils.trimArray(this.selectedHotelIds);
     if (!!selectedHotelIds.length && Array.isArray(selectedHotelIds)) {
       params.selectedHotelIds = selectedHotelIds;
+    }
+
+    if (this.poller.pollCount > this.poller.pollLimit) {
+      params["isLastPolling"] = true;
     }
     return params;
   }

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -343,7 +343,6 @@ var Poller = function(options) {
   this.delays = options.delays;
   this.onSuccessResponse = options.onSuccessResponse;
   this.pollLimit = options.pollLimit;
-  this.forceStop = false;
 };
 
 Poller.prototype = {
@@ -363,6 +362,7 @@ Poller.prototype = {
     }
     this.pollCount = 0;
     this.resultCount = 0;
+    this.forceStop = false;
   },
 
   stop: function() {
@@ -875,20 +875,11 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var originDelays = [0, 300, 600, 900, 2400, 3800, 5000, 6000];
-  var approximateTime = originDelays.reduce((a,b) => a+b);
-  var timeout = 45000;
-  var stepTime = 6000;
-  var extendedDelays = originDelays.slice();
-  while (approximateTime < timeout) {
-    approximateTime += stepTime;
-    extendedDelays.push(stepTime);
-  }
-
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000, 6000, 6000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
-    delays: extendedDelays,
-    pollLimit: extendedDelays.length - 1,
+    delays: delays,
+    pollLimit: delays.length - 1,
     initCallApi: function() {
       return Api.searchHotels(self.getSearchRequestBody(), {
         currencyCode: self.currency.code,

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -875,7 +875,7 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000, 6000, 6000, 6000];
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
     delays: delays,

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -875,7 +875,7 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000];
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
     delays: delays,
@@ -887,7 +887,11 @@ var HotelSearchClient = function(options) {
       });
     },
     callApi: function() {
-      return Api.fetchHotels(self.responseSearch.id, self.fetchHotelsParams());
+      var query = self.fetchHotelsParams();
+      if (self.poller.pollCount > self.poller.pollLimit) {
+        query["isLastPolling"] = true;
+      }
+      return Api.fetchHotels(self.responseSearch.id, query);
     },
     onSuccessResponse: function(response) {
       return self.handleSearchResponse(response);

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -914,11 +914,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    if (response.done) {
-      this.merger.lastMergeResponse(response); 
-    } else {
-      this.merger.mergeResponse(response);  
-    }
+    this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
   },
@@ -1885,20 +1881,11 @@ HotelSearchClient.prototype = {
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    this._mergeRates(response.rates);
-    this._mergeScores(response.scores);
-    this._mergeRatesCounts(response.providerRatesCounts);
-
-    this._cloneHotels(hotelIds);
-  },
-
-  lastMergeResponse: function(response) {
-    var hotelIds = this._getUpdatedHotelIds(response);
-
-    this._mergeStaticData(response);
-    this._mergeHotels(response.hotels);
-    this._mergeFilter(response.filter);
-    this._lastMergeRates(response.rates);
+    if (response.done) {
+      this._lastMergeRates(response.rates);
+    } else {
+      this._mergeRates(response.rates);  
+    }
     this._mergeScores(response.scores);
     this._mergeRatesCounts(response.providerRatesCounts);
 
@@ -1991,44 +1978,34 @@ HotelSearchClient.prototype = {
 
     self._mergeRates(newRates);
 
-    var updatingHotel = [];
-    for (var hotelId in self.__hotelMap) {
-      if (self.__hotelMap[hotelId].rates.length === 1) {
-        updatingHotel.push(hotelId);
-      }
+    var singlePartnerHotels = Object.keys(self.__hotelMap).filter(hotelId => self.__hotelMap[hotelId].rates.length === 1);
+
+    var newPreparedRates = newRates.map(rate => {
+      dataUtils.prepareRate(rate, self.currency, self.__staticData);
+      return rate;
+    });
+
+    var hotelIdToNewRatesMap = newPreparedRates.reduce(function(map, rate) {
+      map[rate.hotelId] = map[rate.hotelId] || [];
+      map[rate.hotelId].push(rate);
+      return map;
+    }, {});
+
+    function compareRates(rate1, rate2) {
+      if (dataUtils.isBetterRate(rate1, rate2)) {
+        return -1;
+      } 
+      return 1;
     }
 
-    for (var i in newRates) {
-      var newRate = newRates[i];
-      dataUtils.prepareRate(newRate, self.currency, self.__staticData);
-      var hotelId = newRate.hotelId;
-      if (updatingHotel.includes(hotelId)) {
-        continue;
-      }
-      var hotel = self.__hotelMap[hotelId];
-      if (!hotel) {
-        continue;
-      }
-
-      var rates = hotel.rates;
-      var isIncluded = false;
-      for (var i = 0; i < rates.length; i++) {
-        if (newRate.id === rates[i].id) {
-          isIncluded = true;
-          break;
-        }
-      }
-      if (isIncluded) {
-        continue;
-      }
-      for (var i = 0; i < rates.length; i++) {
-        if (dataUtils.isBetterRate(newRate, rates[i])) {
-          rates.splice(i, 0, newRate);
-          continue;
-        }
-      }
-      rates.push(newRate);
-    }
+    for (var i in singlePartnerHotels) {
+      var hotelId = singlePartnerHotels[i];
+      var currentBestRate = self.__hotelMap[hotelId].rates[0];
+      var rates = hotelIdToNewRatesMap[hotelId];
+      rates = rates.filter(rate => rate.id !== currentBestRate.id)
+      rates.push(currentBestRate);
+      self.__hotelMap[hotelId].rates = rates.sort(compareRates);
+    } 
   },
 
   _mergeScores: function(scores) {

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -1016,7 +1016,7 @@ HotelSearchClient.prototype = {
     }
 
     if (this.poller.isLastPolling()) {
-      params["isLastPolling"] = true;
+      params.isLastPolling = true;
     }
     return params;
   }
@@ -1997,7 +1997,10 @@ HotelSearchClient.prototype = {
     for (var i in newRates) {
       var rate = newRates[i];
       if (singlePartnerHotels[rate.hotelId]) {
-        var hotelOrderedRates = hotelIdToNewRatesMap[rate.hotelId] || [];
+        if (!hotelIdToNewRatesMap[rate.hotelId]) {
+          hotelIdToNewRatesMap[rate.hotelId] = [];
+        }
+        var hotelOrderedRates = hotelIdToNewRatesMap[rate.hotelId];
         var index;
         for (index = 0; index < hotelOrderedRates.length; index++) {
           if (dataUtils.isBetterRate(rate, hotelOrderedRates[index])) {
@@ -2005,7 +2008,6 @@ HotelSearchClient.prototype = {
           }
         }
         hotelOrderedRates.splice(index, 0, rate);
-        hotelIdToNewRatesMap[rate.hotelId] = hotelOrderedRates;
       }
     }
 

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -373,6 +373,10 @@ Poller.prototype = {
     return this.forceStop;
   },
 
+  isLastPolling: function() {
+    return this.pollCount > this.pollLimit;
+  },
+
   getProgress: function() {
     if (this.pollCount >= this.pollLimit || this.resultCount >= 1000) {
       return 100;
@@ -914,6 +918,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
+    response["isLastPolling"] = this.poller.isLastPolling();
     this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
@@ -1010,7 +1015,7 @@ HotelSearchClient.prototype = {
       params.selectedHotelIds = selectedHotelIds;
     }
 
-    if (this.poller.pollCount > this.poller.pollLimit) {
+    if (this.poller.isLastPolling()) {
       params["isLastPolling"] = true;
     }
     return params;
@@ -1885,7 +1890,7 @@ HotelSearchClient.prototype = {
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    if (response.done) {
+    if (response.done || response.isLastPolling) {
       this._lastMergeRates(response.rates);
     } else {
       this._mergeRates(response.rates);  

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -918,8 +918,8 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    response.isLastPolling = this.poller.isLastPolling();
-    this.merger.mergeResponse(response);  
+    var isSearchEnd = response.done || this.poller.isLastPolling()
+    this.merger.mergeResponse(response, isSearchEnd);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
   },
@@ -1884,13 +1884,13 @@ HotelSearchClient.prototype = {
     this.__filterOptionsMap = this._getEmptyFilterOptionsMap();
   },
 
-  mergeResponse: function(response) {
+  mergeResponse: function(response, isSearchEnd = false) {
     var hotelIds = this._getUpdatedHotelIds(response);
 
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    this._mergeRates(response);  
+    this._mergeRates(response.rates, isSearchEnd);  
     this._mergeScores(response.scores);
     this._mergeRatesCounts(response.providerRatesCounts);
 
@@ -1949,8 +1949,7 @@ HotelSearchClient.prototype = {
     });
   },
 
-  _mergeRates: function(response) {
-    newRates = response.rates;
+  _mergeRates: function(newRates, isSearchEnd) {
     if (!newRates) return;
     var self = this;
 
@@ -1977,7 +1976,7 @@ HotelSearchClient.prototype = {
       }
     });
 
-    if (response.done || response.isLastPolling) {
+    if (isSearchEnd) {
       this._lastMergeRates(newRates);
     }
   },

--- a/src/Poller.js
+++ b/src/Poller.js
@@ -5,6 +5,7 @@ var Poller = function(options) {
   this.delays = options.delays;
   this.onSuccessResponse = options.onSuccessResponse;
   this.pollLimit = options.pollLimit;
+  this.forceStop = false;
 };
 
 Poller.prototype = {
@@ -26,6 +27,14 @@ Poller.prototype = {
     this.resultCount = 0;
   },
 
+  stop: function() {
+    this.forceStop = true;
+  },
+
+  isStopping: function() {
+    return this.forceStop;
+  },
+
   getProgress: function() {
     if (this.pollCount >= this.pollLimit || this.resultCount >= 1000) {
       return 100;
@@ -45,7 +54,7 @@ Poller.prototype = {
 
   preparePoll: function() {
     var self = this;
-    if (this.pollCount < this.delays.length) {
+    if (this.pollCount < this.delays.length && !this.forceStop) {
       this.timer = setTimeout(function() {
         self.poll();
       }, this.delays[this.pollCount]);

--- a/src/Poller.js
+++ b/src/Poller.js
@@ -5,7 +5,6 @@ var Poller = function(options) {
   this.delays = options.delays;
   this.onSuccessResponse = options.onSuccessResponse;
   this.pollLimit = options.pollLimit;
-  this.forceStop = false;
 };
 
 Poller.prototype = {
@@ -25,6 +24,7 @@ Poller.prototype = {
     }
     this.pollCount = 0;
     this.resultCount = 0;
+    this.forceStop = false;
   },
 
   stop: function() {

--- a/src/Poller.js
+++ b/src/Poller.js
@@ -35,6 +35,10 @@ Poller.prototype = {
     return this.forceStop;
   },
 
+  isLastPolling: function() {
+    return this.pollCount > this.pollLimit;
+  },
+
   getProgress: function() {
     if (this.pollCount >= this.pollLimit || this.resultCount >= 1000) {
       return 100;

--- a/src/hotel-search/Merger.js
+++ b/src/hotel-search/Merger.js
@@ -142,6 +142,9 @@ HotelSearchClient.prototype = {
       var hotelId = singlePartnerHotels[i];
       var currentBestRate = self.__hotelMap[hotelId].rates[0];
       var rates = hotelIdToNewRatesMap[hotelId];
+      if (!rates) {
+        continue;
+      }
       rates = rates.filter(rate => rate.id !== currentBestRate.id)
       rates.push(currentBestRate);
       self.__hotelMap[hotelId].rates = rates.sort(compareRates);

--- a/src/hotel-search/Merger.js
+++ b/src/hotel-search/Merger.js
@@ -21,7 +21,7 @@ HotelSearchClient.prototype = {
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    if (response.done) {
+    if (response.done || response.isLastPolling) {
       this._lastMergeRates(response.rates);
     } else {
       this._mergeRates(response.rates);  

--- a/src/hotel-search/Merger.js
+++ b/src/hotel-search/Merger.js
@@ -15,13 +15,13 @@ HotelSearchClient.prototype = {
     this.__filterOptionsMap = this._getEmptyFilterOptionsMap();
   },
 
-  mergeResponse: function(response) {
+  mergeResponse: function(response, isSearchEnd = false) {
     var hotelIds = this._getUpdatedHotelIds(response);
 
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    this._mergeRates(response);  
+    this._mergeRates(response.rates, isSearchEnd);  
     this._mergeScores(response.scores);
     this._mergeRatesCounts(response.providerRatesCounts);
 
@@ -80,8 +80,7 @@ HotelSearchClient.prototype = {
     });
   },
 
-  _mergeRates: function(response) {
-    newRates = response.rates;
+  _mergeRates: function(newRates, isSearchEnd) {
     if (!newRates) return;
     var self = this;
 
@@ -108,7 +107,7 @@ HotelSearchClient.prototype = {
       }
     });
 
-    if (response.done || response.isLastPolling) {
+    if (isSearchEnd) {
       this._lastMergeRates(newRates);
     }
   },

--- a/src/hotel-search/Merger.js
+++ b/src/hotel-search/Merger.js
@@ -21,11 +21,7 @@ HotelSearchClient.prototype = {
     this._mergeStaticData(response);
     this._mergeHotels(response.hotels);
     this._mergeFilter(response.filter);
-    if (response.done || response.isLastPolling) {
-      this._lastMergeRates(response.rates);
-    } else {
-      this._mergeRates(response.rates);  
-    }
+    this._mergeRates(response);  
     this._mergeScores(response.scores);
     this._mergeRatesCounts(response.providerRatesCounts);
 
@@ -84,7 +80,8 @@ HotelSearchClient.prototype = {
     });
   },
 
-  _mergeRates: function(newRates) {
+  _mergeRates: function(response) {
+    newRates = response.rates;
     if (!newRates) return;
     var self = this;
 
@@ -110,45 +107,50 @@ HotelSearchClient.prototype = {
         }
       }
     });
+
+    if (response.done || response.isLastPolling) {
+      this._lastMergeRates(newRates);
+    }
   },
 
   _lastMergeRates: function(newRates) {
     if (!newRates) return;
     var self = this;
 
-    self._mergeRates(newRates);
-
-    var singlePartnerHotels = Object.keys(self.__hotelMap).filter(hotelId => self.__hotelMap[hotelId].rates.length === 1);
-
-    var newPreparedRates = newRates.map(rate => {
-      dataUtils.prepareRate(rate, self.currency, self.__staticData);
-      return rate;
-    });
-
-    var hotelIdToNewRatesMap = newPreparedRates.reduce(function(map, rate) {
-      map[rate.hotelId] = map[rate.hotelId] || [];
-      map[rate.hotelId].push(rate);
-      return map;
-    }, {});
-
-    function compareRates(rate1, rate2) {
-      if (dataUtils.isBetterRate(rate1, rate2)) {
-        return -1;
-      } 
-      return 1;
+    var singlePartnerHotels = {};
+    for (var hotelId in self.__hotelMap) {
+      if (self.__hotelMap[hotelId].rates && self.__hotelMap[hotelId].rates.length === 1) {
+        singlePartnerHotels[hotelId] = true;
+      }
     }
 
-    for (var i in singlePartnerHotels) {
-      var hotelId = singlePartnerHotels[i];
+    var hotelIdToNewRatesMap = {};
+    for (var i in newRates) {
+      var rate = newRates[i];
+      if (singlePartnerHotels[rate.hotelId]) {
+        var hotelOrderedRates = hotelIdToNewRatesMap[rate.hotelId] || [];
+        var index;
+        for (index = 0; index < hotelOrderedRates.length; index++) {
+          if (dataUtils.isBetterRate(rate, hotelOrderedRates[index])) {
+            break;
+          }
+        }
+        hotelOrderedRates.splice(index, 0, rate);
+        hotelIdToNewRatesMap[rate.hotelId] = hotelOrderedRates;
+      }
+    }
+
+    for (var hotelId in singlePartnerHotels) {
       var currentBestRate = self.__hotelMap[hotelId].rates[0];
-      var rates = hotelIdToNewRatesMap[hotelId];
-      if (!rates) {
+      var hotelOrderedRates = hotelIdToNewRatesMap[hotelId];
+      if (!hotelOrderedRates) {
         continue;
       }
-      rates = rates.filter(rate => rate.id !== currentBestRate.id)
-      rates.push(currentBestRate);
-      self.__hotelMap[hotelId].rates = rates.sort(compareRates);
-    } 
+      if (hotelOrderedRates[0].id !== currentBestRate.id) {
+        hotelOrderedRates.splice(0, 0, currentBestRate);
+      }
+      self.__hotelMap[hotelId].rates = hotelOrderedRates;
+    }
   },
 
   _mergeScores: function(scores) {

--- a/src/hotel-search/Merger.js
+++ b/src/hotel-search/Merger.js
@@ -128,7 +128,10 @@ HotelSearchClient.prototype = {
     for (var i in newRates) {
       var rate = newRates[i];
       if (singlePartnerHotels[rate.hotelId]) {
-        var hotelOrderedRates = hotelIdToNewRatesMap[rate.hotelId] || [];
+        if (!hotelIdToNewRatesMap[rate.hotelId]) {
+          hotelIdToNewRatesMap[rate.hotelId] = [];
+        }
+        var hotelOrderedRates = hotelIdToNewRatesMap[rate.hotelId];
         var index;
         for (index = 0; index < hotelOrderedRates.length; index++) {
           if (dataUtils.isBetterRate(rate, hotelOrderedRates[index])) {
@@ -136,7 +139,6 @@ HotelSearchClient.prototype = {
           }
         }
         hotelOrderedRates.splice(index, 0, rate);
-        hotelIdToNewRatesMap[rate.hotelId] = hotelOrderedRates;
       }
     }
 

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -62,11 +62,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    if (response.done) {
-      this.merger.lastMergeResponse(response); 
-    } else {
-      this.merger.mergeResponse(response);  
-    }
+    this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
   },

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -160,7 +160,7 @@ HotelSearchClient.prototype = {
     }
 
     if (this.poller.isLastPolling()) {
-      params["isLastPolling"] = true;
+      params.isLastPolling = true;
     }
     return params;
   }

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -62,6 +62,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
+    response["isLastPolling"] = this.poller.isLastPolling();
     this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
@@ -158,7 +159,7 @@ HotelSearchClient.prototype = {
       params.selectedHotelIds = selectedHotelIds;
     }
 
-    if (this.poller.pollCount > this.poller.pollLimit) {
+    if (this.poller.isLastPolling()) {
       params["isLastPolling"] = true;
     }
     return params;

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -23,7 +23,7 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000, 6000, 6000, 6000];
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
     delays: delays,

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -62,7 +62,7 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    response["isLastPolling"] = this.poller.isLastPolling();
+    response.isLastPolling = this.poller.isLastPolling();
     this.merger.mergeResponse(response);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -35,11 +35,7 @@ var HotelSearchClient = function(options) {
       });
     },
     callApi: function() {
-      var query = self.fetchHotelsParams();
-      if (self.poller.pollCount > self.poller.pollLimit) {
-        query["isLastPolling"] = true;
-      }
-      return Api.fetchHotels(self.responseSearch.id, query);
+      return Api.fetchHotels(self.responseSearch.id, self.fetchHotelsParams());
     },
     onSuccessResponse: function(response) {
       return self.handleSearchResponse(response);
@@ -160,6 +156,10 @@ HotelSearchClient.prototype = {
     var selectedHotelIds = dataUtils.trimArray(this.selectedHotelIds);
     if (!!selectedHotelIds.length && Array.isArray(selectedHotelIds)) {
       params.selectedHotelIds = selectedHotelIds;
+    }
+
+    if (this.poller.pollCount > this.poller.pollLimit) {
+      params["isLastPolling"] = true;
     }
     return params;
   }

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -62,8 +62,8 @@ HotelSearchClient.prototype = {
   },
 
   mergeResponse: function(response) {
-    response.isLastPolling = this.poller.isLastPolling();
-    this.merger.mergeResponse(response);  
+    var isSearchEnd = response.done || this.poller.isLastPolling()
+    this.merger.mergeResponse(response, isSearchEnd);  
     this.lastRatesCount = response.count;
     this.responseSearch = response.search;
   },

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -23,20 +23,11 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var originDelays = [0, 300, 600, 900, 2400, 3800, 5000, 6000];
-  var approximateTime = originDelays.reduce((a,b) => a+b);
-  var timeout = 45000;
-  var stepTime = 6000;
-  var extendedDelays = originDelays.slice();
-  while (approximateTime < timeout) {
-    approximateTime += stepTime;
-    extendedDelays.push(stepTime);
-  }
-
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000, 6000, 6000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
-    delays: extendedDelays,
-    pollLimit: extendedDelays.length - 1,
+    delays: delays,
+    pollLimit: delays.length - 1,
     initCallApi: function() {
       return Api.searchHotels(self.getSearchRequestBody(), {
         currencyCode: self.currency.code,

--- a/src/hotel-search/client.js
+++ b/src/hotel-search/client.js
@@ -23,7 +23,7 @@ var HotelSearchClient = function(options) {
     options.onDisplayedFilterChanged || function() {};
   this.onSearchCreated = options.onSearchCreated || function() {};
 
-  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000, 6000, 6000];
+  var delays = [0, 300, 600, 900, 2400, 3800, 5000, 6000];
   this.merger = new HotelSearchMerger();
   this.poller = new Poller({
     delays: delays,
@@ -35,7 +35,11 @@ var HotelSearchClient = function(options) {
       });
     },
     callApi: function() {
-      return Api.fetchHotels(self.responseSearch.id, self.fetchHotelsParams());
+      var query = self.fetchHotelsParams();
+      if (self.poller.pollCount > self.poller.pollLimit) {
+        query["isLastPolling"] = true;
+      }
+      return Api.fetchHotels(self.responseSearch.id, query);
     },
     onSuccessResponse: function(response) {
       return self.handleSearchResponse(response);

--- a/test/Poller.spec.js
+++ b/test/Poller.spec.js
@@ -119,6 +119,15 @@ describe("Poller", () => {
       poller.preparePoll();
       expect(poller.timer).to.equal(null);
     });
+
+    it("stop the polling process when client request", () =>{
+      poller.delays = [1, 2, 3, 4, 5];
+      poller.pollCount = 3;
+      poller.timer = null;
+      poller.forceStop = true;
+      poller.preparePoll();
+      expect(poller.timer).to.equal(null);
+    });
   });
 
   describe("#retry", () => {

--- a/test/Poller.spec.js
+++ b/test/Poller.spec.js
@@ -120,13 +120,22 @@ describe("Poller", () => {
       expect(poller.timer).to.equal(null);
     });
 
-    it("stop the polling process when client request", () =>{
+    it("stop the polling process when client request", () => {
       poller.delays = [1, 2, 3, 4, 5];
       poller.pollCount = 3;
       poller.timer = null;
       poller.forceStop = true;
       poller.preparePoll();
       expect(poller.timer).to.equal(null);
+    });
+  });
+
+  describe("#isLastPolling", () => {
+    it("return true at the last polling", () => {
+      poller.pollCount = 1;
+      poller.pollLimit = 1;
+      poller.poll();
+      expect(poller.isLastPolling()).to.equal(true);
     });
   });
 

--- a/test/hotel-search/Client.spec.js
+++ b/test/hotel-search/Client.spec.js
@@ -518,5 +518,12 @@ describe("HotelSearchClient", function() {
       var params = client.fetchHotelsParams();
       expect(params.selectedHotelIds).to.deep.equal(["957766"]);
     });
+    it("return isLastPolling flag at the last polling request", function() {
+      client.poller.pollCount = 2;
+      client.poller.pollLimit = 1;
+      var params = client.fetchHotelsParams();
+      console.log(params);
+      expect(params.isLastPolling).to.equal(true);
+    });
   });
 });

--- a/test/hotel-search/Client.spec.js
+++ b/test/hotel-search/Client.spec.js
@@ -299,6 +299,13 @@ describe("HotelSearchClient", function() {
 
       expect(requestBody.selectedHotelIds).to.equal(undefined);
     });
+
+    it("return isLastPolling flag at the last polling request", function() {
+      client.poller.pollCount = 2;
+      client.poller.pollLimit = 1;
+      var params = client.fetchHotelsParams();
+      expect(params.isLastPolling).to.equal(true);
+    });
   });
 
   describe("#mergeResponse", function() {
@@ -331,7 +338,7 @@ describe("HotelSearchClient", function() {
       expect(client.merger.__staticData.brands[1]).to.equal(brand);
     });
 
-    it ("no hotel can have more than 1 rate from a provider when search's status is not'done'", () => {
+    it("no hotel can have more than 1 rate from a provider when search's status is not'done'", () => {
       var response = {
         done: false,
         hotels: [{ id: 1},{ id: 2}],
@@ -350,7 +357,7 @@ describe("HotelSearchClient", function() {
         client.merger.__hotelMap[2].rates[1].providerCode);
     });
 
-    it ("some hotels may have more than 1 from a provider rate when search's status is 'done'", () => {
+    it("some hotels may have more than 1 from a provider rate when search's status is 'done'", () => {
       var response = {
         done: true,
         hotels: [{ id: 1},{ id: 2}],
@@ -517,13 +524,6 @@ describe("HotelSearchClient", function() {
       });
       var params = client.fetchHotelsParams();
       expect(params.selectedHotelIds).to.deep.equal(["957766"]);
-    });
-    it("return isLastPolling flag at the last polling request", function() {
-      client.poller.pollCount = 2;
-      client.poller.pollLimit = 1;
-      var params = client.fetchHotelsParams();
-      console.log(params);
-      expect(params.isLastPolling).to.equal(true);
     });
   });
 });

--- a/test/hotel-search/Client.spec.js
+++ b/test/hotel-search/Client.spec.js
@@ -350,13 +350,32 @@ describe("HotelSearchClient", function() {
           { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}},
         ]
       }
+      client.poller.pollCount = 1;
+      client.poller.pollLimit = 3;
       client.handleSearchResponse(response);
       expect(client.merger.__hotelMap[1].rates.length).to.equal(1);
       expect(client.merger.__hotelMap[2].rates.length).to.equal(2);
       expect(client.merger.__hotelMap[2].rates[0].providerCode).to.not.equal(
         client.merger.__hotelMap[2].rates[1].providerCode);
     });
-
+    it("some hotels may have more than 1 from a provider rate when search's status is not 'done' but reaching limit polling time", () => {
+      var response = {
+        done: true,
+        hotels: [{ id: 1},{ id: 2}],
+        rates: [
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1}},
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1}},
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1}},
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1}},
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}},
+        ]
+      }
+      client.poller.pollCount = 2;
+      client.poller.pollLimit = 1;
+      client.handleSearchResponse(response);
+      expect(client.merger.__hotelMap[1].rates.length).to.equal(3);
+      expect(client.merger.__hotelMap[2].rates.length).to.equal(2);
+    });
     it("some hotels may have more than 1 from a provider rate when search's status is 'done'", () => {
       var response = {
         done: true,

--- a/test/hotel-search/Client.spec.js
+++ b/test/hotel-search/Client.spec.js
@@ -331,7 +331,7 @@ describe("HotelSearchClient", function() {
       expect(client.merger.__staticData.brands[1]).to.equal(brand);
     });
 
-    it("no hotel can have more than 1 rate from a provider when search's status is not'done'", () =>{
+    it ("no hotel can have more than 1 rate from a provider when search's status is not'done'", () => {
       var response = {
         done: false,
         hotels: [{ id: 1},{ id: 2}],
@@ -350,7 +350,7 @@ describe("HotelSearchClient", function() {
         client.merger.__hotelMap[2].rates[1].providerCode);
     });
 
-    it("some hotels may have more than 1 from a provider rate when search's status is 'done'", () =>{
+    it ("some hotels may have more than 1 from a provider rate when search's status is 'done'", () => {
       var response = {
         done: true,
         hotels: [{ id: 1},{ id: 2}],
@@ -363,7 +363,6 @@ describe("HotelSearchClient", function() {
         ]
       }
       client.handleSearchResponse(response);
-      console.log(client.merger.__hotelMap[1]);
       expect(client.merger.__hotelMap[1].rates.length).to.equal(3);
       expect(client.merger.__hotelMap[2].rates.length).to.equal(2);
     });

--- a/test/hotel-search/Client.spec.js
+++ b/test/hotel-search/Client.spec.js
@@ -336,11 +336,11 @@ describe("HotelSearchClient", function() {
         done: false,
         hotels: [{ id: 1},{ id: 2}],
         rates: [
-          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1} },
-          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1} },
-          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1} },
-          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1} },
-          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1} },
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1}},
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1}},
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1}},
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1}},
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}},
         ]
       }
       client.handleSearchResponse(response);
@@ -355,14 +355,15 @@ describe("HotelSearchClient", function() {
         done: true,
         hotels: [{ id: 1},{ id: 2}],
         rates: [
-          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1} },
-          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1} },
-          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1} },
-          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1} },
-          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1} },
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1}},
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1}},
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1}},
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1}},
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}},
         ]
       }
       client.handleSearchResponse(response);
+      console.log(client.merger.__hotelMap[1]);
       expect(client.merger.__hotelMap[1].rates.length).to.equal(3);
       expect(client.merger.__hotelMap[2].rates.length).to.equal(2);
     });

--- a/test/hotel-search/Client.spec.js
+++ b/test/hotel-search/Client.spec.js
@@ -330,6 +330,42 @@ describe("HotelSearchClient", function() {
 
       expect(client.merger.__staticData.brands[1]).to.equal(brand);
     });
+
+    it("no hotel can have more than 1 rate from a provider when search's status is not'done'", () =>{
+      var response = {
+        done: false,
+        hotels: [{ id: 1},{ id: 2}],
+        rates: [
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1} },
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1} },
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1} },
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1} },
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1} },
+        ]
+      }
+      client.handleSearchResponse(response);
+      expect(client.merger.__hotelMap[1].rates.length).to.equal(1);
+      expect(client.merger.__hotelMap[2].rates.length).to.equal(2);
+      expect(client.merger.__hotelMap[2].rates[0].providerCode).to.not.equal(
+        client.merger.__hotelMap[2].rates[1].providerCode);
+    });
+
+    it("some hotels may have more than 1 from a provider rate when search's status is 'done'", () =>{
+      var response = {
+        done: true,
+        hotels: [{ id: 1},{ id: 2}],
+        rates: [
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1} },
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1} },
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1} },
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1} },
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1} },
+        ]
+      }
+      client.handleSearchResponse(response);
+      expect(client.merger.__hotelMap[1].rates.length).to.equal(3);
+      expect(client.merger.__hotelMap[2].rates.length).to.equal(2);
+    });
   });
 
   describe("#updateResults", function() {

--- a/test/hotel-search/Merger.spec.js
+++ b/test/hotel-search/Merger.spec.js
@@ -372,6 +372,23 @@ describe('Merger', function() {
 
       expect(getRateIds(merger.__hotelMap[1].rates)).to.deep.equal([2, 1]);
     });
+
+    it("some hotel may have more than 1 from a provider rate when search's status is 'done'", () =>{
+      var response = {
+        done: true,
+        hotels: [{ id: 1},{ id: 2}],
+        rates: [
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1} },
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1} },
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1} },
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1} },
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1} },
+        ]
+      }
+      merger.lastMergeResponse(response);
+      expect(merger.__hotelMap[1].rates.length).to.equal(3);
+      expect(merger.__hotelMap[2].rates.length).to.equal(2);
+    });
   });
 
   it('merge score', function() {

--- a/test/hotel-search/Merger.spec.js
+++ b/test/hotel-search/Merger.spec.js
@@ -378,14 +378,15 @@ describe('Merger', function() {
         done: true,
         hotels: [{ id: 1},{ id: 2}],
         rates: [
-          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1} },
-          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1} },
-          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1} },
-          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1} },
-          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1} },
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1}},
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1}},
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1}},
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1}},
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}}
         ]
       }
-      merger.lastMergeResponse(response);
+      merger.updateCurrency(null);
+      merger.mergeResponse(response);
       expect(merger.__hotelMap[1].rates.length).to.equal(3);
       expect(merger.__hotelMap[2].rates.length).to.equal(2);
     });

--- a/test/hotel-search/Merger.spec.js
+++ b/test/hotel-search/Merger.spec.js
@@ -373,9 +373,8 @@ describe('Merger', function() {
       expect(getRateIds(merger.__hotelMap[1].rates)).to.deep.equal([2, 1]);
     });
 
-    it("some hotel may have more than 1 from a provider rate when search's status is 'done'", () => {
+    it("some hotel may have more than 1 from a provider rate when search's is end", () => {
       var response = {
-        done: true,
         hotels: [{ id: 1},{ id: 2}],
         rates: [
           { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1}},
@@ -386,26 +385,7 @@ describe('Merger', function() {
         ]
       }
       merger.updateCurrency(null);
-      merger.mergeResponse(response);
-      expect(merger.__hotelMap[1].rates.length).to.equal(3);
-      expect(merger.__hotelMap[2].rates.length).to.equal(2);
-    });
-
-    it("some hotel may have more than 1 from a provider rate at the last polling even the search's status is not 'done'", () => {
-      var response = {
-        done: false,
-        hotels: [{ id: 1},{ id: 2}],
-        rates: [
-          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1}},
-          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1}},
-          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1}},
-          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1}},
-          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}}
-        ],
-        isLastPolling: true
-      }
-      merger.updateCurrency(null);
-      merger.mergeResponse(response);
+      merger.mergeResponse(response, true);
       expect(merger.__hotelMap[1].rates.length).to.equal(3);
       expect(merger.__hotelMap[2].rates.length).to.equal(2);
     });

--- a/test/hotel-search/Merger.spec.js
+++ b/test/hotel-search/Merger.spec.js
@@ -373,7 +373,7 @@ describe('Merger', function() {
       expect(getRateIds(merger.__hotelMap[1].rates)).to.deep.equal([2, 1]);
     });
 
-    it ("some hotel may have more than 1 from a provider rate when search's status is 'done'", () => {
+    it("some hotel may have more than 1 from a provider rate when search's status is 'done'", () => {
       var response = {
         done: true,
         hotels: [{ id: 1},{ id: 2}],
@@ -384,6 +384,25 @@ describe('Merger', function() {
           { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1}},
           { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}}
         ]
+      }
+      merger.updateCurrency(null);
+      merger.mergeResponse(response);
+      expect(merger.__hotelMap[1].rates.length).to.equal(3);
+      expect(merger.__hotelMap[2].rates.length).to.equal(2);
+    });
+
+    it("some hotel may have more than 1 from a provider rate at the last polling even the search's status is not 'done'", () => {
+      var response = {
+        done: false,
+        hotels: [{ id: 1},{ id: 2}],
+        rates: [
+          { id: 1, hotelId: 1, providerCode: "a.com", price: {amount: 100, taxAmountUsd: 1}},
+          { id: 2, hotelId: 1, providerCode: "a.com", price: {amount: 110, taxAmountUsd: 1}},
+          { id: 3, hotelId: 2, providerCode: "a.com", price: {amount: 120, taxAmountUsd: 1}},
+          { id: 4, hotelId: 2, providerCode: "b.com", price: {amount: 130, taxAmountUsd: 1}},
+          { id: 5, hotelId: 1, providerCode: "a.com", price: {amount: 140, taxAmountUsd: 1}}
+        ],
+        isLastPolling: true
       }
       merger.updateCurrency(null);
       merger.mergeResponse(response);

--- a/test/hotel-search/Merger.spec.js
+++ b/test/hotel-search/Merger.spec.js
@@ -373,7 +373,7 @@ describe('Merger', function() {
       expect(getRateIds(merger.__hotelMap[1].rates)).to.deep.equal([2, 1]);
     });
 
-    it("some hotel may have more than 1 from a provider rate when search's status is 'done'", () =>{
+    it ("some hotel may have more than 1 from a provider rate when search's status is 'done'", () => {
       var response = {
         done: true,
         hotels: [{ id: 1},{ id: 2}],


### PR DESCRIPTION
### Purpose
The backend API have added a status to let people know when the search is done. According to this change, this PR will make the SDK keep polling results until its search has completed.
On the other hand, when a search has done, there maybe some extra fares for hotels has only one single partner. Hence, the PR also modified the way our SDK do merge those rates on the last polling

### Approach
1. Add a flag isLastPolling to hotel search polling request. This will let backend return more rates for those single-partner hotels even the search has not done yet.
2. Add a flag "forceStop" to Poller.js to stop polling. It lets the sdk client could stop its poller if the search has done.
3. On the last polling or Search done, the Merger.js will accept any duplicated provider rates from the response for hotels have only one partner. 