### PR TITLE
add credentials on fetch get request

### DIFF
--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -294,6 +294,7 @@ var Api = {
   get: function(uri, query) {
     return fetch(this.buildUrl(uri, query), {
       method: "GET",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json"
       }

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -294,6 +294,7 @@ var Api = {
   get: function(uri, query) {
     return fetch(this.buildUrl(uri, query), {
       method: "GET",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json"
       }

--- a/src/Api.js
+++ b/src/Api.js
@@ -115,6 +115,7 @@ var Api = {
   get: function(uri, query) {
     return fetch(this.buildUrl(uri, query), {
       method: "GET",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json"
       }


### PR DESCRIPTION
This change is mainly for AWS sticky session. They send rolling cookie and it must be sent along with the request.

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch

### Sending a request with credentials included

> To cause browsers to send a request with credentials included, even for a cross-origin call, add credentials: 'include' to the init object you pass to the fetch() method.

