### PR TITLE
sort direct_priority rates on top when prices are in parity

### DIFF
--- a/build/bower.bundle.js
+++ b/build/bower.bundle.js
@@ -2145,11 +2145,13 @@ HotelSearchClient.prototype = {
               totalTaxAmountA = a.price.totalTaxAmount,
               totalTaxAmountB = b.price.totalTaxAmount;
 
-            if (totalAmountA - totalTaxAmountA === totalAmountB - totalTaxAmountB) {
-              return b.price.ecpc - a.price.ecpc;
-            } else {
-              return (totalAmountA - totalTaxAmountA) - (totalAmountB - totalTaxAmountB);
-            }
+            var basePriceA = totalAmountA - totalTaxAmountA,
+              basePriceB = totalAmountB - totalTaxAmountB;
+
+            if (basePriceA !== basePriceB) return basePriceA - basePriceB;
+            if (a.provider.type === 'DIRECT_PRIORITY' && b.provider.type !== 'DIRECT_PRIORITY') return -1;
+            if (b.provider.type === 'DIRECT_PRIORITY' && a.provider.type !== 'DIRECT_PRIORITY') return 1;
+            return b.price.ecpc - a.price.ecpc;
           });
 
         self.__hotelMap[hotelId].sortedRatesByBasePrice = sortedCloneRates;

--- a/build/npm.bundle.js
+++ b/build/npm.bundle.js
@@ -2145,11 +2145,13 @@ HotelSearchClient.prototype = {
               totalTaxAmountA = a.price.totalTaxAmount,
               totalTaxAmountB = b.price.totalTaxAmount;
 
-            if (totalAmountA - totalTaxAmountA === totalAmountB - totalTaxAmountB) {
-              return b.price.ecpc - a.price.ecpc;
-            } else {
-              return (totalAmountA - totalTaxAmountA) - (totalAmountB - totalTaxAmountB);
-            }
+            var basePriceA = totalAmountA - totalTaxAmountA,
+              basePriceB = totalAmountB - totalTaxAmountB;
+
+            if (basePriceA !== basePriceB) return basePriceA - basePriceB;
+            if (a.provider.type === 'DIRECT_PRIORITY' && b.provider.type !== 'DIRECT_PRIORITY') return -1;
+            if (b.provider.type === 'DIRECT_PRIORITY' && a.provider.type !== 'DIRECT_PRIORITY') return 1;
+            return b.price.ecpc - a.price.ecpc;
           });
 
         self.__hotelMap[hotelId].sortedRatesByBasePrice = sortedCloneRates;

--- a/src/hotel-search/Merger.js
+++ b/src/hotel-search/Merger.js
@@ -131,11 +131,13 @@ HotelSearchClient.prototype = {
               totalTaxAmountA = a.price.totalTaxAmount,
               totalTaxAmountB = b.price.totalTaxAmount;
 
-            if (totalAmountA - totalTaxAmountA === totalAmountB - totalTaxAmountB) {
-              return b.price.ecpc - a.price.ecpc;
-            } else {
-              return (totalAmountA - totalTaxAmountA) - (totalAmountB - totalTaxAmountB);
-            }
+            var basePriceA = totalAmountA - totalTaxAmountA,
+              basePriceB = totalAmountB - totalTaxAmountB;
+
+            if (basePriceA !== basePriceB) return basePriceA - basePriceB;
+            if (a.provider.type === 'DIRECT_PRIORITY' && b.provider.type !== 'DIRECT_PRIORITY') return -1;
+            if (b.provider.type === 'DIRECT_PRIORITY' && a.provider.type !== 'DIRECT_PRIORITY') return 1;
+            return b.price.ecpc - a.price.ecpc;
           });
 
         self.__hotelMap[hotelId].sortedRatesByBasePrice = sortedCloneRates;

--- a/test/hotel-search/Merger.spec.js
+++ b/test/hotel-search/Merger.spec.js
@@ -447,6 +447,12 @@ describe('Merger', function() {
         }
       };
 
+      var provider1 = {
+        id: 1,
+        code: "a",
+        type: "OTA"
+      };
+
       var rate2 = {
         id: 2,
         hotelId: 1,
@@ -458,10 +464,33 @@ describe('Merger', function() {
         }
       };
 
+      var provider2 = {
+        id: 2,
+        code: "b",
+        type: "DIRECT_PRIORITY"
+      };
+
       var rate3 = {
         id: 3,
         hotelId: 1,
         providerCode: "c",
+        price: {
+          totalAmount: 10,
+          totalTaxAmount: 0,
+          ecpc: 0.05
+        }
+      };
+
+      var provider3 = {
+        id: 3,
+        code: "c",
+        type: "DIRECT_PRIORITY"
+      };
+
+      var rate4 = {
+        id: 4,
+        hotelId: 1,
+        providerCode: "d",
         price: {
           totalAmount: 25,
           totalTaxAmount: 10,
@@ -469,12 +498,19 @@ describe('Merger', function() {
         }
       };
 
+      var provider4 = {
+        id: 4,
+        code: "d",
+        type: "DIRECT"
+      };
+
       merger.mergeResponse({
         hotels: [{ id: 1 }],
-        rates: [rate1, rate2, rate3],
+        rates: [rate1, rate2, rate3, rate4],
+        providers: [provider1, provider2, provider3, provider4]
       });
 
-      expect(getRateIds(merger.__hotelMap[1].sortedRatesByBasePrice)).to.deep.equal([2, 1, 3]);
+      expect(getRateIds(merger.__hotelMap[1].sortedRatesByBasePrice)).to.deep.equal([2, 3, 1, 4]);
 
     });
   });


### PR DESCRIPTION
### Purpose
https://wegomushi.atlassian.net/browse/BE-1332

When the provider status is set to direct priority, when rates are in parity, irrespective of the cpc's of various providers the direct priority provider has to be displayed on top.

### Status
- [x] deployed and tested on staging
